### PR TITLE
cm: fix the cursor line-height when setting font

### DIFF
--- a/panel/codemirror/lib/codemirror.js
+++ b/panel/codemirror/lib/codemirror.js
@@ -69,7 +69,7 @@
     this.doc = doc;
 
     var input = new CodeMirror.inputStyles[options.inputStyle](this);
-    var display = this.display = new Display(place, doc, input);
+    var display = this.display = new Display(place, doc, input, options);
     display.wrapper.CodeMirror = this;
     updateGutters(this);
     themeChanged(this);
@@ -130,7 +130,7 @@
   // and content drawing. It holds references to DOM nodes and
   // display-related state.
 
-  function Display(place, doc, input) {
+  function Display(place, doc, input, options) {
     var d = this;
     this.input = input;
 
@@ -170,6 +170,7 @@
     d.scroller.setAttribute("tabIndex", "-1");
     // The element in which the editor lives.
     d.wrapper = elt("div", [d.scrollbarFiller, d.gutterFiller, d.scroller], "CodeMirror");
+    d.wrapper.style.lineHeight = options.cursorHeight;
 
     // Work around IE7 z-index bug (not perfect, hence IE7 not really being supported)
     if (ie && ie_version < 8) { d.gutters.style.zIndex = -1; d.scroller.style.paddingRight = 0; }
@@ -2269,7 +2270,7 @@
     var cursor = output.appendChild(elt("div", "\u00a0", "CodeMirror-cursor"));
     cursor.style.left = pos.left + "px";
     cursor.style.top = pos.top + "px";
-    cursor.style.height = Math.max(0, pos.bottom - pos.top) * cm.options.cursorHeight + "px";
+    cursor.style.height = (Math.max(0, pos.bottom - pos.top) * cm.options.cursorHeight - 2) + "px";
 
     if (pos.other) {
       // Secondary cursor, shown when on a 'jump' in bi-directional text

--- a/panel/index.css
+++ b/panel/index.css
@@ -8,10 +8,10 @@
 body {
   margin: 0;
   padding: 0;
-  font-family: 'DejaVu Sans Mono';
 }
 
-.CodeMirror {
+body>.CodeMirror {
   height: 100%;
-  font-size: 14px;
+  font-size: 13px;
+  font-family: 'DejaVu Sans Mono';
 }

--- a/panel/page.js
+++ b/panel/page.js
@@ -14,6 +14,7 @@ document.addEventListener('DOMContentLoaded', function(event) {
     'keyMap': 'sublime',
     'lineNumbers': true,
     'fontFamily': 'DejaVu Sans Mono',
+    'cursorHeight': 1.2,
     'autoCloseBrackets': true,
     'matchBrackets': true,
     'autoComplete': true,


### PR DESCRIPTION
when setting the font-family, the cm source only compute the cursor
height, the system should make sure the below elements:

- .CodeMirror
- .CodeMirror-cursor

would have the same font-family and line-height.

Plus, tweaked the cursor height by -2 to make it closer to the font-size.

R=@jwu