### PR TITLE
auto completion can not work correctly on windows

### DIFF
--- a/panel/esprima/esprimaJsContentAssist.js
+++ b/panel/esprima/esprimaJsContentAssist.js
@@ -2418,6 +2418,9 @@ EsprimaJavaScriptContentAssistProvider.prototype = {
      * @param {String} fileName
      */
     computeSummary: function(buffer, fileName) {
+        // windows file name will includes ':', and ':' is used to separate
+        // return type and parameters in function description
+        fileName = fileName.replace(':', '/');
         var root = mVisitor.parse(buffer);
         if (!root) {
             // assume a bad parse


### PR DESCRIPTION
因为在windows上，文件路径包含了`:`而导致问题。